### PR TITLE
file.Read MOD -> GAME for mounted content; ttt_playerspawn remap; disabled skip hooks

### DIFF
--- a/lua/server/sv_weaponplacer.lua
+++ b/lua/server/sv_weaponplacer.lua
@@ -22,7 +22,7 @@ weaponPlacer.mapSpawnPoints = weaponPlacer.mapSpawnPoints or nil
 function weaponPlacer:GetCurrentMapScript(useTTT)
 	local map = game.GetMap()
 	local fileName = self:GetCurrentMapScriptName(useTTT)
-	return file.Read(fileName, useTTT and "MOD" or "DATA")
+	return file.Read(fileName, useTTT and "GAME" or "DATA")
 end
 
 function weaponPlacer:GetCurrentMapScriptName(useTTT)
@@ -98,7 +98,7 @@ function weaponPlacer:ConvertCurrentMapScriptToWeaponPlacerScript()
 	local tttFileName = self:GetCurrentMapScriptName(true)
 	local weaponPlacerFileName = self:GetCurrentMapScriptName()
 
-	if not file.Exists(tttFileName, "MOD") then
+	if not file.Exists(tttFileName, "GAME") then
 		return false
 	end
 

--- a/lua/server/sv_weaponplacer.lua
+++ b/lua/server/sv_weaponplacer.lua
@@ -255,10 +255,18 @@ hook.Add("PlayerDisconnected", "WeaponPlacerPlayerDropped", function(ply)
 end)
 
 hook.Add("Initialize", "WeaponPlacerDisableSpawnScripts", function()
+	if not GetConVar("weapon_placer_enabled"):GetBool() then
+		return
+	end
+
 	GetConVar("ttt_use_weapon_spawn_scripts"):SetBool(false)
 end)
 
 hook.Add("InitPostEntity", "WeaponPlacerGetMapEntities", function()
+	if not GetConVar("weapon_placer_enabled"):GetBool() then
+		return
+	end
+
 	if not weaponPlacer.mapEntities then
 		weaponPlacer.mapEntities = {}
 

--- a/lua/server/sv_weaponplacer_prep.lua
+++ b/lua/server/sv_weaponplacer_prep.lua
@@ -106,11 +106,14 @@ function weaponPlacer:CreateImportedEnt(class, pos, ang, kv)
 	return true
 end
 
+local classremap = {
+	ttt_playerspawn = "info_player_deathmatch"
+}
 function weaponPlacer:ImportEntities()
 	local ents = self:GetEntitiesFromScript(self:GetCurrentMapScript())
 
 	for _, ent in ipairs(ents) do
-		self:CreateImportedEnt(ent.class, ent.pos, ent.ang, ent.kv)
+		self:CreateImportedEnt(classremap[ent.class] or ent.class, ent.pos, ent.ang, ent.kv)
 	end
 end
 

--- a/lua/server/sv_weaponplacer_prep.lua
+++ b/lua/server/sv_weaponplacer_prep.lua
@@ -120,7 +120,7 @@ function weaponPlacer.PrepareRound()
 	end
 
 	local weaponPlacerFileExists = file.Exists(weaponPlacer:GetCurrentMapScriptName(), "DATA")
-	local tttFileExists = file.Exists(weaponPlacer:GetCurrentMapScriptName(true), "MOD")
+	local tttFileExists = file.Exists(weaponPlacer:GetCurrentMapScriptName(true), "GAME")
 
 	if not weaponPlacerFileExists then
 		if not tttFileExists then


### PR DESCRIPTION
Example Map: https://steamcommunity.com/sharedfiles/filedetails/?id=285372790
Packed rearm script was not being identified causing only a single playerspawn to exist and players would all spawn in that location or be killed if there was not a valid adhoc spawn created for them.

Some maps are packed with rearm scripts and were not being read with file.Read MOD option, changed to GAME to include mounted content (packed in maps, or possibly from mounted addons).

This map also included the use of ttt_playerspawn entity that used to get remapped here: https://github.com/Facepunch/garrysmod/blob/9bbd7c8af0dda5bed88e3f09fbdf5d4be7e012f2/garrysmod/gamemodes/terrortown/gamemode/ent_replace.lua#L520

If weaponplacer is disabled, skip the init hooks to avoid interfering with base ent_replace